### PR TITLE
fix crossdomain login state of cookie

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "invocie-management-frontend",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://ec2-35-89-139-214.us-west-2.compute.amazonaws.com:8888",
   "dependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",

--- a/src/App.js
+++ b/src/App.js
@@ -11,7 +11,6 @@ import { Route, Switch } from "react-router-dom";
 import { ToastContainer } from "react-toastify";
 
 import axios from "axios";
-axios.defaults.baseURL = "http://ec2-35-89-139-214.us-west-2.compute.amazonaws.com:8888";
 
 class App extends Component {
   render() {


### PR DESCRIPTION
# Fixed the cross domain issue by using react proxy.
See file changes.

# Other Solutions
## A) Fix the cross domain issue without proxy:
-  First, we need to set cookie configuration on backend:
```
http-only: false
same-site: none
secure: false
```
- Second, we need to enable https for backend:
```
When the SameSite=None attribute is present, an additional Secure attribute must be used so cross-site cookies can only be accessed over HTTPS connections.
```
Reference: [get-ready-for-new-samesitenone-secure](https://developers.google.com/search/blog/2020/01/get-ready-for-new-samesitenone-secure)


- Third, we need to set headers on backend:
```
 resp.setHeader("Access-Control-Allow-Origin", "http://localhost:3000"); 
 resp.setHeader("Access-Control-Allow-Credentials", "true"); 
```

- Last, set headers on frontend:
```
 withCredentials: true 
```

## B) Use JWT or manually send cookie to backend